### PR TITLE
Phone: avoid traceback when phone number contains 0 or 1

### DIFF
--- a/phone.rb
+++ b/phone.rb
@@ -18,6 +18,8 @@ def letters_for_number num
       ['T', 'U', 'V']
     when 9 
       ['W' ,'X', 'Y']
+    else
+      []
   end  
 end
 
@@ -33,7 +35,7 @@ def phone_options number
   join_sets set
 end
 
-phone_options 1023456789
+phone_options '102-345-6789'
 =begin
   
 "ACE"


### PR DESCRIPTION
- phone: handle all digits to avoid TB
- phone: ignore non-digit characters in phone number, such as '-'.
