### PR TITLE
Fix powerset algorithm

### DIFF
--- a/src/powerset.rb
+++ b/src/powerset.rb
@@ -1,11 +1,11 @@
 #powerset - subset of set
 def powerset(arr)
-  result = [[]] 
+  result = [[]]
   arr.each do |num|
-    (0...arr.size).each do |j|
+    (0...result.size).each do |j|
       result << result[j] + [num]
     end
-  end 
+  end
   result
 end
 


### PR DESCRIPTION
Since aca7bb1ba6ceb48ced0f7731b72a673880656027 the powerset algorithm
produces an array of size N*N instead of 2^N.

This change fixes the bounds of the inner loop. The
upper bound should be `result.size` instead.